### PR TITLE
Add validation and rename tea command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner <command> [optio
 | 커맨드    | 옵션                                  | 설명                                                       |
 |-----------|---------------------------------------|------------------------------------------------------------|
 | bridge    | `<extension> <mode> <collectionId>`   | SCD/JSON 생성 스크립트 실행 (`bridge.sh`)                 |
-| tea2      | `<collectionId> <listenerIP> <port>`  | TEA2 사전 처리 스크립트 실행 (`tea2_util.sh`)              |
+| tea       | `<collectionId> <listenerIP> <port>`  | TEA2 사전 처리 스크립트 실행 (`tea2_util.sh`)              |
 | gateway   | `<collectionId> <operation> <mode>`   | 변환/인덱싱 스크립트 실행 (`gateway.sh`)                   |
 
 - **extension**: `scd` 또는 `json`
@@ -89,7 +89,7 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner <command> [optio
 java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd static 12345
 
 # TEA2 유틸리티 실행
-java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea2 12345 127.0.0.1 9000
+java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
 
 # JSON dynamic 모드로 gateway
 java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic
@@ -113,10 +113,10 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 co
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
   ```
 
-- **2-3.** bridge(scd/static) → tea2 → convert-json → convert-vector → index-json(static)
+ - **2-3.** bridge(scd/static) → tea → convert-json → convert-vector → index-json(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd static 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea2 12345 127.0.0.1 9000
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json static
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
@@ -136,10 +136,10 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 co
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic
   ```
 
-- **2-7.** bridge(scd/dynamic) → tea2 → convert-json → convert-vector → index-json(dynamic)
+ - **2-7.** bridge(scd/dynamic) → tea → convert-json → convert-vector → index-json(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd dynamic 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea2 12345 127.0.0.1 9000
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic

--- a/src/com/pipeline/DataPipelineRunner.java
+++ b/src/com/pipeline/DataPipelineRunner.java
@@ -1,6 +1,24 @@
 package com.pipeline;
 
 public class DataPipelineRunner {
+
+    // 확장자가 scd 또는 json 인지 확인
+    private static boolean isValidExtension(String ext) {
+        return "scd".equals(ext) || "json".equals(ext);
+    }
+
+    // 실행 모드가 static 또는 dynamic 인지 확인
+    private static boolean isValidMode(String mode) {
+        return "static".equals(mode) || "dynamic".equals(mode);
+    }
+
+    // gateway 명령의 operation 값 유효성 검사
+    private static boolean isValidOperation(String op) {
+        return "convert-json".equals(op) ||
+               "convert-vector".equals(op) ||
+               "index-json".equals(op) ||
+               "index-scd".equals(op);
+    }
     public static void main(String[] args) {
         if (args.length == 0) {
             System.out.println("Usage: java DataPipelineRunner <command> [options]");
@@ -9,6 +27,7 @@ public class DataPipelineRunner {
 
         String command = args[0];
 
+        // 명령어에 따라 각 스크립트를 실행
         try {
             switch (command) {
                 case "bridge":
@@ -18,6 +37,14 @@ public class DataPipelineRunner {
                     }
                     String extension = args[1];
                     String mode = args[2];
+                    if (!isValidExtension(extension)) {
+                        System.out.println("Invalid extension: " + extension + " (allowed: scd, json)");
+                        System.exit(1);
+                    }
+                    if (!isValidMode(mode)) {
+                        System.out.println("Invalid mode: " + mode + " (allowed: static, dynamic)");
+                        System.exit(1);
+                    }
                     String collectionId = args[3];
                     new ProcessBuilder("sh", "bridge.sh", extension, mode, collectionId)
                             .inheritIO()
@@ -25,9 +52,9 @@ public class DataPipelineRunner {
                             .waitFor();
                     break;
 
-                case "tea2":
+                case "tea":
                     if (args.length != 4) {
-                        System.out.println("Usage: tea2 <collectionId> <listenerIP> <port>");
+                        System.out.println("Usage: tea <collectionId> <listenerIP> <port>");
                         System.exit(1);
                     }
                     collectionId = args[1];
@@ -47,6 +74,14 @@ public class DataPipelineRunner {
                     collectionId = args[1];
                     String operation = args[2];
                     mode = args[3];
+                    if (!isValidOperation(operation)) {
+                        System.out.println("Invalid operation: " + operation + " (allowed: convert-json, convert-vector, index-json, index-scd)");
+                        System.exit(1);
+                    }
+                    if (!isValidMode(mode)) {
+                        System.out.println("Invalid mode: " + mode + " (allowed: static, dynamic)");
+                        System.exit(1);
+                    }
                     new ProcessBuilder("sh", "gateway.sh", collectionId, operation, mode)
                             .inheritIO()
                             .start()


### PR DESCRIPTION
## Summary
- rename `tea2` command to `tea`
- update README to match new command name
- add Korean comments for validation helpers

## Testing
- `javac -d out/dpr src/com/pipeline/DataPipelineRunner.java`


------
https://chatgpt.com/codex/tasks/task_e_685ca15e8fb0832c84ab4b496c194a64