### PR TITLE
Add prevStep option for gateway command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner <command> [optio
 |-----------|---------------------------------------|------------------------------------------------------------|
 | bridge    | `<extension> <mode> <collectionId>`   | SCD/JSON 생성 스크립트 실행 (`bridge.sh`)                 |
 | tea       | `<collectionId> <listenerIP> <port>`  | TEA2 사전 처리 스크립트 실행 (`tea2_util.sh`)              |
-| gateway   | `<collectionId> <operation> <mode>`   | 변환/인덱싱 스크립트 실행 (`gateway.sh`)                   |
+| gateway   | `<collectionId> <operation> <mode> [prevStep]`   | 변환/인덱싱 스크립트 실행 (`gateway.sh`)                   |
 
 - **extension**: `scd` 또는 `json`
 - **mode**: `static` 또는 `dynamic`  
@@ -81,6 +81,8 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner <command> [optio
 - **collectionId**: 작업 대상 컬렉션 식별자
 - **listenerIP**, **port**: TEA2 유틸리티 리스너 정보
 - **operation**: `convert-json`/`convert-vector`/`index-json`/`index-scd`
+- **prevStep**: 이전 단계 이름. 지정하면 해당 단계의 결과 디렉터리에서 파일을
+  이동한 뒤 `gateway.sh`를 실행합니다. 생략하면 파일 이동 없이 실행합니다.
 
 ---
 
@@ -98,8 +100,8 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd stati
 # TEA2 유틸리티 실행
 java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
 
-# JSON dynamic 모드로 gateway
-java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic
+# JSON dynamic 모드로 gateway (이전 단계가 tea2_util.sh인 경우)
+java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic tea
 ```
 
 ### 전체 파이프라인 시나리오
@@ -109,73 +111,73 @@ java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 co
 - **2-1.** bridge(scd/static) → index-scd(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd static 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-scd static
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-scd static bridge
   ```
 
 - **2-2.** bridge(scd/static) → convert-json → convert-vector → index-json(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd static 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json static
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json static bridge
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static convert-json
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static convert-vector
   ```
 
  - **2-3.** bridge(scd/static) → tea → convert-json → convert-vector → index-json(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd static 12345
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json static
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json static tea
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static convert-json
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static convert-vector
   ```
 
 - **2-5.** bridge(scd/dynamic) → index-scd(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd dynamic 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-scd dynamic
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-scd dynamic bridge
   ```
 
 - **2-6.** bridge(scd/dynamic) → convert-json → convert-vector → index-json(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd dynamic 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic bridge
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic convert-json
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic convert-vector
   ```
 
  - **2-7.** bridge(scd/dynamic) → tea → convert-json → convert-vector → index-json(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge scd dynamic 12345
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner tea 12345 127.0.0.1 9000
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-json dynamic tea
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic convert-json
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic convert-vector
   ```
 
 - **2-8.** bridge(json/static) → index-json(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge json static 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static bridge
   ```
 
 - **2-9.** bridge(json/static) → convert-vector → index-json(static)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge json static 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector static bridge
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json static convert-vector
   ```
 
 - **2-10.** bridge(json/dynamic) → index-json(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge json dynamic 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic bridge
   ```
 
 - **2-11.** bridge(json/dynamic) → convert-vector → index-json(dynamic)
   ```bash
   java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner bridge json dynamic 12345
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic
-  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 convert-vector dynamic bridge
+  java -cp ${SF1_HOME}/lib/custom com.pipeline.DataPipelineRunner gateway 12345 index-json dynamic convert-vector
   ```
 
 ---

--- a/src/com/pipeline/DataPipelineRunner.java
+++ b/src/com/pipeline/DataPipelineRunner.java
@@ -58,6 +58,16 @@ public class DataPipelineRunner {
                "index-scd".equals(op);
     }
 
+    // 이전 단계 이름이 유효한지 확인
+    private static boolean isValidPrevStep(String step) {
+        return "bridge".equals(step) ||
+               "tea".equals(step) ||
+               "convert-json".equals(step) ||
+               "convert-vector".equals(step) ||
+               "index-json".equals(step) ||
+               "index-scd".equals(step);
+    }
+
     // 지정한 확장자의 파일을 대상 디렉토리로 이동
     private static void moveFiles(String srcDir, String destDir, String extension) throws IOException {
         Path src = Paths.get(srcDir);
@@ -84,25 +94,41 @@ public class DataPipelineRunner {
     }
 
     // gateway.sh 실행 전 필요한 파일 이동 처리
-    private static void prepareForGateway(String collectionId, String operation) throws IOException {
+    private static void prepareForGateway(String collectionId, String operation, String prevStep) throws IOException {
+        if (prevStep == null) {
+            // 이전 단계 정보가 없으면 파일 이동을 수행하지 않는다.
+            return;
+        }
+
         String base = collectionBaseDir + collectionId;
         switch (operation) {
             case "convert-json":
-                moveFiles(base + "/scd/tea_done", base + "/convert-json/index", "scd");
-                moveFiles(base + "/scd/static", base + "/convert-json/index", "scd");
-                moveFiles(base + "/scd/dynamic", base + "/convert-json/index", "scd");
+                if ("tea".equals(prevStep)) {
+                    moveFiles(base + "/scd/tea_done", base + "/convert-json/index", "scd");
+                } else if ("bridge".equals(prevStep)) {
+                    moveFiles(base + "/scd/static", base + "/convert-json/index", "scd");
+                    moveFiles(base + "/scd/dynamic", base + "/convert-json/index", "scd");
+                }
                 break;
             case "convert-vector":
-                moveFiles(base + "/convert-json/backup", base + "/convert-vector/index", "json");
+                if ("convert-json".equals(prevStep)) {
+                    moveFiles(base + "/convert-json/backup", base + "/convert-vector/index", "json");
+                }
                 break;
             case "index-json":
-                moveFiles(base + "/convert-vector/backup", base + "/json/index", "json");
-                moveFiles(base + "/convert-json/backup", base + "/json/index", "json");
+                if ("convert-vector".equals(prevStep)) {
+                    moveFiles(base + "/convert-vector/backup", base + "/json/index", "json");
+                } else if ("convert-json".equals(prevStep)) {
+                    moveFiles(base + "/convert-json/backup", base + "/json/index", "json");
+                }
                 break;
             case "index-scd":
-                moveFiles(base + "/scd/tea_done", base + "/scd/index", "scd");
-                moveFiles(base + "/scd/static", base + "/scd/index", "scd");
-                moveFiles(base + "/scd/dynamic", base + "/scd/index", "scd");
+                if ("tea".equals(prevStep)) {
+                    moveFiles(base + "/scd/tea_done", base + "/scd/index", "scd");
+                } else if ("bridge".equals(prevStep)) {
+                    moveFiles(base + "/scd/static", base + "/scd/index", "scd");
+                    moveFiles(base + "/scd/dynamic", base + "/scd/index", "scd");
+                }
                 break;
         }
     }
@@ -155,13 +181,14 @@ public class DataPipelineRunner {
                     break;
 
                 case "gateway":
-                    if (args.length != 4) {
-                        System.out.println("Usage: gateway <collectionId> <operation> <mode>");
+                    if (args.length < 4 || args.length > 5) {
+                        System.out.println("Usage: gateway <collectionId> <operation> <mode> [prevStep]");
                         System.exit(1);
                     }
                     collectionId = args[1];
                     String operation = args[2];
                     mode = args[3];
+                    String prevStep = args.length == 5 ? args[4] : null;
                     if (!isValidOperation(operation)) {
                         System.out.println("Invalid operation: " + operation + " (allowed: convert-json, convert-vector, index-json, index-scd)");
                         System.exit(1);
@@ -170,7 +197,11 @@ public class DataPipelineRunner {
                         System.out.println("Invalid mode: " + mode + " (allowed: static, dynamic)");
                         System.exit(1);
                     }
-                    prepareForGateway(collectionId, operation);
+                    if (prevStep != null && !isValidPrevStep(prevStep)) {
+                        System.out.println("Invalid prevStep: " + prevStep + " (allowed: bridge, tea, convert-json, convert-vector, index-json, index-scd)");
+                        System.exit(1);
+                    }
+                    prepareForGateway(collectionId, operation, prevStep);
                     new ProcessBuilder("sh", "gateway.sh", collectionId, operation, mode)
                             .inheritIO()
                             .start()


### PR DESCRIPTION
## Summary
- add optional `prevStep` argument for `gateway` command
- allow `prepareForGateway` to choose source directory based on previous step
- document `prevStep` usage in README
- handle null `prevStep` by skipping any file moves

## Testing
- `javac -d out/dpr src/com/pipeline/DataPipelineRunner.java`


------
https://chatgpt.com/codex/tasks/task_e_685de2e6a71c832cab730c6faa8a1dc3